### PR TITLE
updates drupal requirements to 8.6.10 (security update)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,14 +20,14 @@
         "cweagans/composer-patches": "^1.6",
         "drupal-composer/drupal-scaffold": "^2.5",
         "drupal/console": "^1.0.2",
-        "drupal/core": "~8.5.3",
+        "drupal/core": "~8.6.10",
         "drush/drush": "^9.0.0",
         "vlucas/phpdotenv": "^2.4",
         "webflo/drupal-finder": "^1.0.0",
         "webmozart/path-util": "^2.3"
     },
     "require-dev": {
-        "webflo/drupal-core-require-dev": "~8.5.3"
+        "webflo/drupal-core-require-dev": "~8.6.10"
     },
     "conflict": {
         "drupal/drupal": "*"


### PR DESCRIPTION
Without this change, 8.5.x is the latest installed. Updated requirements to 8.6.10 at minimum. I ran `fin init` to get a successful installation.